### PR TITLE
matt/recursive cte eliminate distribution and coalesce in recursive children

### DIFF
--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -1156,6 +1156,7 @@ dependencies = [
  "parking_lot",
  "rand",
  "tempfile",
+ "tokio",
  "url",
 ]
 
@@ -1248,6 +1249,7 @@ dependencies = [
  "tempfile",
  "termtree",
  "tokio",
+ "tokio-stream",
  "uuid",
 ]
 

--- a/datafusion/common/src/dfschema.rs
+++ b/datafusion/common/src/dfschema.rs
@@ -753,6 +753,11 @@ impl DFField {
         self.field = f.into();
         self
     }
+
+    pub fn with_qualifier(mut self, qualifier: impl Into<OwnedTableReference>) -> Self {
+        self.qualifier = Some(qualifier.into());
+        self
+    }
 }
 
 impl From<FieldRef> for DFField {

--- a/datafusion/core/src/physical_optimizer/enforce_distribution.rs
+++ b/datafusion/core/src/physical_optimizer/enforce_distribution.rs
@@ -1241,10 +1241,6 @@ fn ensure_distribution(
     dist_context: DistributionContext,
     config: &ConfigOptions,
 ) -> Result<Transformed<DistributionContext>> {
-    let mut dist_context = dist_context;
-    if is_recursive_query(&dist_context.plan) {
-        dist_context.has_recursive_ancestor = true;
-    }
     if dist_context.has_recursive_ancestor {
         return Ok(Transformed::No(dist_context));
     }
@@ -1436,7 +1432,7 @@ fn ensure_distribution(
             plan.clone().with_new_children(new_children)?
         },
         distribution_onwards,
-        has_recursive_ancestor: has_recursive_ancestor || is_recursive_query(&plan),
+        has_recursive_ancestor,
     };
     Ok(Transformed::Yes(new_distribution_context))
 }
@@ -1457,6 +1453,8 @@ struct DistributionContext {
 
 impl DistributionContext {
     /// Creates an empty context.
+    /// Only use this method at the root of the plan.
+    /// All other contexts should be created using `new_descendent`.
     fn new(plan: Arc<dyn ExecutionPlan>) -> Self {
         let length = plan.children().len();
         DistributionContext {
@@ -1466,13 +1464,19 @@ impl DistributionContext {
         }
     }
 
-    fn new_from_plan_with_parent(
-        parent: Arc<dyn ExecutionPlan>,
-        cur_plan: Arc<dyn ExecutionPlan>,
-    ) -> Self {
-        let mut ctx = Self::new(cur_plan);
-        ctx.has_recursive_ancestor =
-            is_recursive_query(&parent) || ctx.has_recursive_ancestor;
+    /// Creates a new context from a descendent plan.
+    /// Importantly, this function propagates the `has_recursive_ancestor` flag.
+    fn new_descendent(&self, descendent_plan: Arc<dyn ExecutionPlan>) -> Self {
+        let mut ctx = Self::new(descendent_plan);
+        ctx.has_recursive_ancestor |= self.has_recursive_ancestor;
+        ctx
+    }
+
+    /// Creates a new context from a descendent context.
+    /// Importantly, this function propagates the `has_recursive_ancestor` flag.
+    fn new_descendent_from_ctx(&self, ctx: Self) -> Self {
+        let mut ctx = ctx;
+        ctx.has_recursive_ancestor |= self.has_recursive_ancestor;
         ctx
     }
 
@@ -1547,7 +1551,6 @@ impl DistributionContext {
                 }
             })
             .collect();
-
         Ok(DistributionContext {
             has_recursive_ancestor: is_recursive_query(&parent_plan),
             plan: with_new_children_if_necessary(parent_plan, children_plans)?.into(),
@@ -1560,15 +1563,7 @@ impl DistributionContext {
         self.plan
             .children()
             .into_iter()
-            .map(|child| {
-                let mut ctx = DistributionContext::new_from_plan_with_parent(
-                    self.plan.clone(),
-                    child,
-                );
-                ctx.has_recursive_ancestor =
-                    self.has_recursive_ancestor || ctx.has_recursive_ancestor;
-                ctx
-            })
+            .map(|child| self.new_descendent(child))
             .collect()
     }
 }
@@ -1600,10 +1595,12 @@ impl TreeNode for DistributionContext {
                 .into_iter()
                 .map(transform)
                 .collect::<Result<Vec<_>>>()?;
-            let mut ctx =
-                DistributionContext::new_from_children_nodes(children_nodes, self.plan)?;
-            ctx.has_recursive_ancestor |= self.has_recursive_ancestor;
-            Ok(ctx)
+
+            DistributionContext::new_from_children_nodes(
+                children_nodes,
+                self.plan.clone(),
+            )
+            .map(|ctx| self.new_descendent_from_ctx(ctx))
         }
     }
 }

--- a/datafusion/core/src/physical_optimizer/utils.rs
+++ b/datafusion/core/src/physical_optimizer/utils.rs
@@ -17,6 +17,8 @@
 
 //! Collection of utility functions that are leveraged by the query optimizer rules
 
+use datafusion_expr::RecursiveQuery;
+use datafusion_physical_plan::recursive_query::RecursiveQueryExec;
 use itertools::concat;
 use std::borrow::Borrow;
 use std::collections::HashSet;
@@ -219,6 +221,10 @@ pub fn is_union(plan: &Arc<dyn ExecutionPlan>) -> bool {
 /// Checks whether the given operator is a [`RepartitionExec`].
 pub fn is_repartition(plan: &Arc<dyn ExecutionPlan>) -> bool {
     plan.as_any().is::<RepartitionExec>()
+}
+
+pub fn is_recursive_query(plan: &Arc<dyn ExecutionPlan>) -> bool {
+    plan.as_any().is::<RecursiveQueryExec>()
 }
 
 /// Utility function yielding a string representation of the given [`ExecutionPlan`].

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -50,6 +50,7 @@ use crate::physical_expr::create_physical_expr;
 use crate::physical_optimizer::optimizer::PhysicalOptimizerRule;
 use crate::physical_plan::aggregates::{AggregateExec, AggregateMode, PhysicalGroupBy};
 use crate::physical_plan::analyze::AnalyzeExec;
+use crate::physical_plan::continuance::ContinuanceExec;
 use crate::physical_plan::explain::ExplainExec;
 use crate::physical_plan::expressions::{Column, PhysicalSortExpr};
 use crate::physical_plan::filter::FilterExec;
@@ -58,6 +59,7 @@ use crate::physical_plan::joins::SortMergeJoinExec;
 use crate::physical_plan::joins::{CrossJoinExec, NestedLoopJoinExec};
 use crate::physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
 use crate::physical_plan::projection::ProjectionExec;
+use crate::physical_plan::recursive_query::RecursiveQueryExec;
 use crate::physical_plan::repartition::RepartitionExec;
 use crate::physical_plan::sorts::sort::SortExec;
 use crate::physical_plan::unnest::UnnestExec;
@@ -87,7 +89,9 @@ use datafusion_expr::expr::{
 };
 use datafusion_expr::expr_rewriter::{unalias, unnormalize_cols};
 use datafusion_expr::logical_plan::builder::wrap_projection_for_join_if_necessary;
-use datafusion_expr::{DescribeTable, DmlStatement, StringifiedPlan, WriteOp};
+use datafusion_expr::{
+    DescribeTable, DmlStatement, NamedRelation, RecursiveQuery, StringifiedPlan, WriteOp,
+};
 use datafusion_expr::{WindowFrame, WindowFrameBound};
 use datafusion_physical_expr::expressions::Literal;
 use datafusion_sql::utils::window_expr_common_partition_keys;
@@ -1316,6 +1320,29 @@ impl DefaultPhysicalPlanner {
                         Ok(plan)
                     }
                 }
+                LogicalPlan::RecursiveQuery(RecursiveQuery { name, static_term, recursive_term, is_distinct }) => {
+                    let static_term = self.create_initial_plan(static_term, session_state).await?;
+                    let recursive_term = self.create_initial_plan(recursive_term, session_state).await?;
+
+                    Ok(Arc::new(RecursiveQueryExec::new(name.clone(), static_term, recursive_term, *is_distinct)))
+                }
+                LogicalPlan::NamedRelation(NamedRelation {name, schema}) => {
+                    // Named relations is how we represent access to any sort of dynamic data provider. They
+                    // differ from tables in the sense that they can start existing dynamically during the
+                    // execution of a query and then disappear before it even finishes.
+                    //
+                    // This system allows us to replicate the tricky behavior of classical databases where a
+                    // temporary "working table" (as it is called in Postgres) can be used when dealing with
+                    // complex operations (such as recursive CTEs) and then can be dropped. Since DataFusion
+                    // at its core is heavily stream-based and vectorized, we try to avoid using 'real' tables
+                    // and let the streams take care of the data flow in this as well.
+
+                    // Since the actual "input"'s will be only available to us at runtime (through task context)
+                    // we can't really do any sort of meaningful validation here.
+                    let schema = SchemaRef::new(schema.as_ref().to_owned().into());
+                    Ok(Arc::new(ContinuanceExec::new(name.clone(), schema)))
+                }
+
             };
             exec_plan
         }.boxed()

--- a/datafusion/execution/Cargo.toml
+++ b/datafusion/execution/Cargo.toml
@@ -45,4 +45,5 @@ object_store = "0.7.0"
 parking_lot = "0.12"
 rand = "0.8"
 tempfile = "3"
+tokio = { version = "1.28", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }
 url = "2.2"

--- a/datafusion/execution/src/task.rs
+++ b/datafusion/execution/src/task.rs
@@ -33,13 +33,14 @@ use crate::{
     runtime_env::{RuntimeConfig, RuntimeEnv},
 };
 
-use arrow::{error::Result as ArrowResult, record_batch::RecordBatch};
-use futures::channel::mpsc::Receiver as SingleChannelReceiver;
+use arrow::record_batch::RecordBatch;
+// use futures::channel::mpsc::Receiver as SingleChannelReceiver;
+use tokio::sync::mpsc::Receiver as SingleChannelReceiver;
 // use futures::lock::Mutex;
 use parking_lot::Mutex;
 // use futures::
 
-type RelationHandler = SingleChannelReceiver<ArrowResult<RecordBatch>>;
+type RelationHandler = SingleChannelReceiver<Result<RecordBatch>>;
 
 /// Task Execution Context
 ///

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -54,6 +54,8 @@ use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
 use std::sync::Arc;
 
+use super::plan::{NamedRelation, RecursiveQuery};
+
 /// Default table name for unnamed table
 pub const UNNAMED_TABLE: &str = "?table?";
 
@@ -118,6 +120,39 @@ impl LogicalPlanBuilder {
             produce_one_row,
             schema: DFSchemaRef::new(DFSchema::empty()),
         }))
+    }
+
+    /// A named temporary relation with a schema.
+    ///
+    /// This is used to represent a relation that does not exist at the
+    /// planning stage, but will be created at execution time with the
+    /// given schema.
+    pub fn named_relation(name: &str, schema: DFSchemaRef) -> Self {
+        Self::from(LogicalPlan::NamedRelation(NamedRelation {
+            name: name.to_string(),
+            schema,
+        }))
+    }
+
+    /// Convert a regular plan into a recursive query.
+    pub fn to_recursive_query(
+        &self,
+        name: String,
+        recursive_term: LogicalPlan,
+        is_distinct: bool,
+    ) -> Result<Self> {
+        // TODO: we need to do a bunch of validation here. Maybe more.
+        if is_distinct {
+            return Err(DataFusionError::NotImplemented(
+                "Recursive queries with distinct is not supported".to_string(),
+            ));
+        }
+        Ok(Self::from(LogicalPlan::RecursiveQuery(RecursiveQuery {
+            name,
+            static_term: Arc::new(self.plan.clone()),
+            recursive_term: Arc::new(recursive_term),
+            is_distinct,
+        })))
     }
 
     /// Create a values list based relation, and the schema is inferred from data, consuming

--- a/datafusion/expr/src/logical_plan/mod.rs
+++ b/datafusion/expr/src/logical_plan/mod.rs
@@ -34,9 +34,10 @@ pub use ddl::{
 pub use dml::{DmlStatement, WriteOp};
 pub use plan::{
     Aggregate, Analyze, CrossJoin, DescribeTable, Distinct, EmptyRelation, Explain,
-    Extension, Filter, Join, JoinConstraint, JoinType, Limit, LogicalPlan, Partitioning,
-    PlanType, Prepare, Projection, Repartition, Sort, StringifiedPlan, Subquery,
-    SubqueryAlias, TableScan, ToStringifiedPlan, Union, Unnest, Values, Window,
+    Extension, Filter, Join, JoinConstraint, JoinType, Limit, LogicalPlan, NamedRelation,
+    Partitioning, PlanType, Prepare, Projection, RecursiveQuery, Repartition, Sort,
+    StringifiedPlan, Subquery, SubqueryAlias, TableScan, ToStringifiedPlan, Union,
+    Unnest, Values, Window,
 };
 pub use statement::{
     SetVariable, Statement, TransactionAccessMode, TransactionConclusion, TransactionEnd,

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -110,6 +110,8 @@ pub enum LogicalPlan {
     /// produces 0 or 1 row. This is used to implement SQL `SELECT`
     /// that has no values in the `FROM` clause.
     EmptyRelation(EmptyRelation),
+    /// A named temporary relation with a schema.
+    NamedRelation(NamedRelation),
     /// Produces the output of running another query.  This is used to
     /// implement SQL subqueries
     Subquery(Subquery),
@@ -152,6 +154,8 @@ pub enum LogicalPlan {
     /// Unnest a column that contains a nested list type such as an
     /// ARRAY. This is used to implement SQL `UNNEST`
     Unnest(Unnest),
+    /// A variadic query (e.g. "Recursive CTEs")
+    RecursiveQuery(RecursiveQuery),
 }
 
 impl LogicalPlan {
@@ -188,6 +192,11 @@ impl LogicalPlan {
             LogicalPlan::Copy(CopyTo { input, .. }) => input.schema(),
             LogicalPlan::Ddl(ddl) => ddl.schema(),
             LogicalPlan::Unnest(Unnest { schema, .. }) => schema,
+            LogicalPlan::NamedRelation(NamedRelation { schema, .. }) => schema,
+            LogicalPlan::RecursiveQuery(RecursiveQuery { static_term, .. }) => {
+                // we take the schema of the static term as the schema of the entire recursive query
+                static_term.schema()
+            }
         }
     }
 
@@ -230,6 +239,7 @@ impl LogicalPlan {
             LogicalPlan::Explain(_)
             | LogicalPlan::Analyze(_)
             | LogicalPlan::EmptyRelation(_)
+            | LogicalPlan::NamedRelation(_)
             | LogicalPlan::Ddl(_)
             | LogicalPlan::Dml(_)
             | LogicalPlan::Copy(_)
@@ -239,6 +249,10 @@ impl LogicalPlan {
             | LogicalPlan::Extension(_)
             | LogicalPlan::TableScan(_) => {
                 vec![self.schema()]
+            }
+            LogicalPlan::RecursiveQuery(RecursiveQuery { static_term, .. }) => {
+                // return only the schema of the static term
+                static_term.all_schemas()
             }
             // return children schemas
             LogicalPlan::Limit(_)
@@ -371,6 +385,9 @@ impl LogicalPlan {
             }
             // plans without expressions
             LogicalPlan::EmptyRelation(_)
+            | LogicalPlan::NamedRelation(_)
+            // TODO: not sure if this should go here
+            | LogicalPlan::RecursiveQuery(_)
             | LogicalPlan::Subquery(_)
             | LogicalPlan::SubqueryAlias(_)
             | LogicalPlan::Limit(_)
@@ -415,8 +432,14 @@ impl LogicalPlan {
             LogicalPlan::Ddl(ddl) => ddl.inputs(),
             LogicalPlan::Unnest(Unnest { input, .. }) => vec![input],
             LogicalPlan::Prepare(Prepare { input, .. }) => vec![input],
+            LogicalPlan::RecursiveQuery(RecursiveQuery {
+                static_term,
+                recursive_term,
+                ..
+            }) => vec![static_term, recursive_term],
             // plans without inputs
             LogicalPlan::TableScan { .. }
+            | LogicalPlan::NamedRelation(_)
             | LogicalPlan::Statement { .. }
             | LogicalPlan::EmptyRelation { .. }
             | LogicalPlan::Values { .. }
@@ -492,6 +515,9 @@ impl LogicalPlan {
                     cross.left.head_output_expr()
                 }
             }
+            LogicalPlan::RecursiveQuery(RecursiveQuery { static_term, .. }) => {
+                static_term.head_output_expr()
+            }
             LogicalPlan::Union(union) => Ok(Some(Expr::Column(
                 union.schema.fields()[0].qualified_column(),
             ))),
@@ -511,6 +537,7 @@ impl LogicalPlan {
             }
             LogicalPlan::Subquery(_) => Ok(None),
             LogicalPlan::EmptyRelation(_)
+            | LogicalPlan::NamedRelation(_)
             | LogicalPlan::Prepare(_)
             | LogicalPlan::Statement(_)
             | LogicalPlan::Values(_)
@@ -839,6 +866,14 @@ impl LogicalPlan {
                     input: Arc::new(inputs[0].clone()),
                 }))
             }
+            LogicalPlan::RecursiveQuery(RecursiveQuery {
+                name, is_distinct, ..
+            }) => Ok(LogicalPlan::RecursiveQuery(RecursiveQuery {
+                name: name.clone(),
+                static_term: Arc::new(inputs[0].clone()),
+                recursive_term: Arc::new(inputs[1].clone()),
+                is_distinct: *is_distinct,
+            })),
             LogicalPlan::Analyze(a) => {
                 assert!(expr.is_empty());
                 assert_eq!(inputs.len(), 1);
@@ -877,6 +912,7 @@ impl LogicalPlan {
                 }))
             }
             LogicalPlan::EmptyRelation(_)
+            | LogicalPlan::NamedRelation(_)
             | LogicalPlan::Ddl(_)
             | LogicalPlan::Statement(_) => {
                 // All of these plan types have no inputs / exprs so should not be called
@@ -1040,6 +1076,9 @@ impl LogicalPlan {
                 }),
             LogicalPlan::TableScan(TableScan { fetch, .. }) => *fetch,
             LogicalPlan::EmptyRelation(_) => Some(0),
+            // TODO: not sure if this is correct
+            LogicalPlan::NamedRelation(_) => None,
+            LogicalPlan::RecursiveQuery(_) => None,
             LogicalPlan::Subquery(_) => None,
             LogicalPlan::SubqueryAlias(SubqueryAlias { input, .. }) => input.max_rows(),
             LogicalPlan::Limit(Limit { fetch, .. }) => *fetch,
@@ -1387,6 +1426,14 @@ impl LogicalPlan {
             fn fmt(&self, f: &mut Formatter) -> fmt::Result {
                 match self.0 {
                     LogicalPlan::EmptyRelation(_) => write!(f, "EmptyRelation"),
+                    LogicalPlan::NamedRelation(NamedRelation { name, .. }) => {
+                        write!(f, "NamedRelation: {}", name)
+                    }
+                    LogicalPlan::RecursiveQuery(RecursiveQuery {
+                        is_distinct, ..
+                    }) => {
+                        write!(f, "RecursiveQuery: is_distinct={}", is_distinct)
+                    }
                     LogicalPlan::Values(Values { ref values, .. }) => {
                         let str_values: Vec<_> = values
                             .iter()
@@ -1683,6 +1730,28 @@ pub struct EmptyRelation {
     pub produce_one_row: bool,
     /// The schema description of the output
     pub schema: DFSchemaRef,
+}
+
+/// A named temporary relation with a known schema.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct NamedRelation {
+    /// The relation name
+    pub name: String,
+    /// The schema description
+    pub schema: DFSchemaRef,
+}
+
+/// A variadic query operation
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct RecursiveQuery {
+    /// Name of the query
+    pub name: String,
+    /// The static term
+    pub static_term: Arc<LogicalPlan>,
+    /// The recursive term
+    pub recursive_term: Arc<LogicalPlan>,
+    /// Distinction
+    pub is_distinct: bool,
 }
 
 /// Values expression. See

--- a/datafusion/optimizer/src/common_subexpr_eliminate.rs
+++ b/datafusion/optimizer/src/common_subexpr_eliminate.rs
@@ -366,6 +366,8 @@ impl OptimizerRule for CommonSubexprEliminate {
             | LogicalPlan::Dml(_)
             | LogicalPlan::Copy(_)
             | LogicalPlan::Unnest(_)
+            | LogicalPlan::NamedRelation(_)
+            | LogicalPlan::RecursiveQuery(_)
             | LogicalPlan::Prepare(_) => {
                 // apply the optimization to all inputs of the plan
                 utils::optimize_children(self, plan, config)?

--- a/datafusion/physical-plan/Cargo.toml
+++ b/datafusion/physical-plan/Cargo.toml
@@ -60,4 +60,5 @@ tempfile = "3"
 #[dev-dependencies]
 termtree = "0.4.1"
 tokio = { version = "1.28", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }
+tokio-stream = { version = "0.1.14" }
 uuid = { version = "^1.2", features = ["v4"] }

--- a/datafusion/physical-plan/src/continuance.rs
+++ b/datafusion/physical-plan/src/continuance.rs
@@ -1,0 +1,166 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Defines the continuance query plan
+
+use std::any::Any;
+use std::sync::Arc;
+
+// use crate::error::{DataFusionError, Result};
+// use crate::physical_plan::{
+//     DisplayFormatType, Distribution, ExecutionPlan, Partitioning,
+// };
+use arrow::datatypes::SchemaRef;
+use datafusion_execution::TaskContext;
+use datafusion_physical_expr::Partitioning;
+
+use crate::{DisplayAs, DisplayFormatType, ExecutionPlan};
+
+use super::expressions::PhysicalSortExpr;
+use super::stream::RecordBatchReceiverStream;
+use super::{
+    metrics::{ExecutionPlanMetricsSet, MetricsSet},
+    SendableRecordBatchStream, Statistics,
+};
+use datafusion_common::{DataFusionError, Result};
+
+// use crate::exe::context::TaskContext;
+
+/// A temporary "working table" operation wehre the input data will be
+/// taken from the named handle during the execution and will be re-published
+/// as is (kind of like a mirror).
+///
+/// Most notably used in the implementation of recursive queries where the
+/// underlying relation does not exist yet but the data will come as the previous
+/// term is evaluated.
+#[derive(Debug)]
+pub struct ContinuanceExec {
+    /// Name of the relation handler
+    name: String,
+    /// The schema of the stream
+    schema: SchemaRef,
+    /// Execution metrics
+    metrics: ExecutionPlanMetricsSet,
+}
+
+impl ContinuanceExec {
+    /// Create a new execution plan for a continuance stream. The given relation
+    /// handler must exist in the task context before calling [`execute`] on this
+    /// plan.
+    pub fn new(name: String, schema: SchemaRef) -> Self {
+        Self {
+            name,
+            schema,
+            metrics: ExecutionPlanMetricsSet::new(),
+        }
+    }
+}
+
+impl DisplayAs for ContinuanceExec {
+    fn fmt_as(
+        &self,
+        t: DisplayFormatType,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                // TODO: add more details
+                write!(f, "ContinuanceExec: name={}", self.name)
+            }
+        }
+    }
+}
+
+impl ExecutionPlan for ContinuanceExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn output_partitioning(&self) -> Partitioning {
+        Partitioning::UnknownPartitioning(1)
+    }
+
+    fn maintains_input_order(&self) -> Vec<bool> {
+        vec![false]
+    }
+
+    fn benefits_from_input_partitioning(&self) -> Vec<bool> {
+        vec![false]
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(ContinuanceExec::new(
+            self.name.clone(),
+            self.schema.clone(),
+        )))
+    }
+
+    /// This plan does not come with any special streams, but rather we use
+    /// the existing [`RecordBatchReceiverStream`] to receive the data from
+    /// the registered handle.
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        // Continuance streams must be the plan base.
+        if partition != 0 {
+            return Err(DataFusionError::Internal(format!(
+                "ContinuanceExec got an invalid partition {} (expected 0)",
+                partition
+            )));
+        }
+
+        // let stream = Box::pin(CombinedRecordBatchStream::new(
+        //     self.schema(),
+        //     input_stream_vec,
+        // ));
+        // return Ok(Box::pin(ObservedStream::new(stream, baseline_metrics)));
+
+        // The relation handler must be already registered by the
+        // parent op.
+        let receiver = context.pop_relation_handler(self.name.clone())?;
+        // TODO: this looks wrong.
+        Ok(RecordBatchReceiverStream::builder(self.schema.clone(), 1).build())
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+
+    fn statistics(&self) -> Statistics {
+        Statistics::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {}

--- a/datafusion/physical-plan/src/continuance.rs
+++ b/datafusion/physical-plan/src/continuance.rs
@@ -27,26 +27,32 @@ use std::sync::Arc;
 use arrow::datatypes::SchemaRef;
 use datafusion_execution::TaskContext;
 use datafusion_physical_expr::Partitioning;
+use tokio_stream::wrappers::ReceiverStream;
 
+use crate::stream::RecordBatchStreamAdapter;
 use crate::{DisplayAs, DisplayFormatType, ExecutionPlan};
 
 use super::expressions::PhysicalSortExpr;
-use super::stream::RecordBatchReceiverStream;
+
 use super::{
     metrics::{ExecutionPlanMetricsSet, MetricsSet},
     SendableRecordBatchStream, Statistics,
 };
 use datafusion_common::{DataFusionError, Result};
+// use tokio::stream::;
 
 // use crate::exe::context::TaskContext;
 
-/// A temporary "working table" operation wehre the input data will be
+/// A temporary "working table" operation where the input data will be
 /// taken from the named handle during the execution and will be re-published
 /// as is (kind of like a mirror).
 ///
 /// Most notably used in the implementation of recursive queries where the
 /// underlying relation does not exist yet but the data will come as the previous
-/// term is evaluated.
+/// term is evaluated. This table will be used such that the recursive plan
+/// will register a receiver in the task context and this plan will use that
+/// receiver to get the data and stream it back up so that the batches are available
+/// in the next iteration.
 #[derive(Debug)]
 pub struct ContinuanceExec {
     /// Name of the relation handler
@@ -59,7 +65,7 @@ pub struct ContinuanceExec {
 
 impl ContinuanceExec {
     /// Create a new execution plan for a continuance stream. The given relation
-    /// handler must exist in the task context before calling [`execute`] on this
+    /// handler must exist in the task context before calling [`ContinuanceExec::execute`] on this
     /// plan.
     pub fn new(name: String, schema: SchemaRef) -> Self {
         Self {
@@ -78,7 +84,6 @@ impl DisplayAs for ContinuanceExec {
     ) -> std::fmt::Result {
         match t {
             DisplayFormatType::Default | DisplayFormatType::Verbose => {
-                // TODO: add more details
                 write!(f, "ContinuanceExec: name={}", self.name)
             }
         }
@@ -125,7 +130,7 @@ impl ExecutionPlan for ContinuanceExec {
     }
 
     /// This plan does not come with any special streams, but rather we use
-    /// the existing [`RecordBatchReceiverStream`] to receive the data from
+    /// the existing [`RecordBatchStreamAdapter`] to receive the data from
     /// the registered handle.
     fn execute(
         &self,
@@ -140,17 +145,13 @@ impl ExecutionPlan for ContinuanceExec {
             )));
         }
 
-        // let stream = Box::pin(CombinedRecordBatchStream::new(
-        //     self.schema(),
-        //     input_stream_vec,
-        // ));
-        // return Ok(Box::pin(ObservedStream::new(stream, baseline_metrics)));
-
         // The relation handler must be already registered by the
         // parent op.
         let receiver = context.pop_relation_handler(self.name.clone())?;
-        // TODO: this looks wrong.
-        Ok(RecordBatchReceiverStream::builder(self.schema.clone(), 1).build())
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            self.schema.clone(),
+            ReceiverStream::new(receiver),
+        )))
     }
 
     fn metrics(&self) -> Option<MetricsSet> {

--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -326,13 +326,13 @@ impl Stream for FilterExecStream {
             match self.input.poll_next_unpin(cx) {
                 Poll::Ready(value) => match value {
                     Some(Ok(batch)) => {
-                        let timer = self.baseline_metrics.elapsed_compute().timer();
+                        // let timer = self.baseline_metrics.elapsed_compute().timer();
                         let filtered_batch = batch_filter(&batch, &self.predicate)?;
                         // skip entirely filtered batches
                         if filtered_batch.num_rows() == 0 {
                             continue;
                         }
-                        timer.done();
+                        // timer.done();
                         poll = Poll::Ready(Some(Ok(filtered_batch)));
                         break;
                     }

--- a/datafusion/physical-plan/src/lib.rs
+++ b/datafusion/physical-plan/src/lib.rs
@@ -337,6 +337,7 @@ pub mod analyze;
 pub mod coalesce_batches;
 pub mod coalesce_partitions;
 pub mod common;
+pub mod continuance;
 pub mod display;
 pub mod empty;
 pub mod explain;

--- a/datafusion/physical-plan/src/lib.rs
+++ b/datafusion/physical-plan/src/lib.rs
@@ -348,6 +348,7 @@ pub mod limit;
 pub mod memory;
 pub mod metrics;
 pub mod projection;
+pub mod recursive_query;
 pub mod repartition;
 mod row_converter;
 pub mod sorts;

--- a/datafusion/physical-plan/src/recursive_query.rs
+++ b/datafusion/physical-plan/src/recursive_query.rs
@@ -119,6 +119,13 @@ impl ExecutionPlan for RecursiveQueryExec {
         vec![false, false]
     }
 
+    fn required_input_distribution(&self) -> Vec<datafusion_physical_expr::Distribution> {
+        vec![
+            datafusion_physical_expr::Distribution::SinglePartition,
+            datafusion_physical_expr::Distribution::SinglePartition,
+        ]
+    }
+
     fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
         None
     }

--- a/datafusion/physical-plan/src/recursive_query.rs
+++ b/datafusion/physical-plan/src/recursive_query.rs
@@ -1,0 +1,355 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Defines the recursive query plan
+
+use std::any::Any;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use arrow::datatypes::SchemaRef;
+use arrow::record_batch::RecordBatch;
+use datafusion_common::{DataFusionError, Result};
+use datafusion_execution::TaskContext;
+use datafusion_physical_expr::Partitioning;
+use futures::{Stream, StreamExt};
+use tokio::sync::mpsc;
+
+use super::expressions::PhysicalSortExpr;
+use super::metrics::BaselineMetrics;
+use super::RecordBatchStream;
+use super::{
+    metrics::{ExecutionPlanMetricsSet, MetricsSet},
+    SendableRecordBatchStream, Statistics,
+};
+use arrow::error::ArrowError;
+use tokio::sync::mpsc::{Receiver, Sender};
+
+// use crate::execution::context::TaskContext;
+use crate::{DisplayAs, DisplayFormatType, ExecutionPlan};
+
+/// Recursive query execution plan.
+///
+/// This plan has two components: a base part (the static term) and
+/// a dynamic part (the recursive term). The execution will start from
+/// the base, and as long as the previous iteration produced at least
+/// a single new row (taking care of the distinction) the recursive
+/// part will be continuously executed.
+///
+/// Before each execution of the dynamic part, the rows from the previous
+/// iteration will be available in a "working table" (not a real table,
+/// can be only accessed using a continuance operation).
+///
+/// Note that there won't be any limit or checks applied to detect
+/// an infinite recursion, so it is up to the planner to ensure that
+/// it won't happen.
+#[derive(Debug)]
+pub struct RecursiveQueryExec {
+    /// Name of the query handler
+    name: String,
+    /// The base part (static term)
+    static_term: Arc<dyn ExecutionPlan>,
+    /// The dynamic part (recursive term)
+    recursive_term: Arc<dyn ExecutionPlan>,
+    /// Distinction
+    is_distinct: bool,
+    /// Execution metrics
+    metrics: ExecutionPlanMetricsSet,
+}
+
+impl RecursiveQueryExec {
+    /// Create a new RecursiveQueryExec
+    pub fn new(
+        name: String,
+        static_term: Arc<dyn ExecutionPlan>,
+        recursive_term: Arc<dyn ExecutionPlan>,
+        is_distinct: bool,
+    ) -> Self {
+        RecursiveQueryExec {
+            name,
+            static_term,
+            recursive_term,
+            is_distinct,
+            metrics: ExecutionPlanMetricsSet::new(),
+        }
+    }
+}
+
+impl ExecutionPlan for RecursiveQueryExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.static_term.schema()
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![self.static_term.clone(), self.recursive_term.clone()]
+    }
+
+    // Distribution on a recursive query is really tricky to handle.
+    // For now, we are going to use a single partition but in the
+    // future we might find a better way to handle this.
+    fn output_partitioning(&self) -> Partitioning {
+        Partitioning::UnknownPartitioning(1)
+    }
+
+    // TODO: control these hints and see whether we can
+    // infer some from the child plans (static/recurisve terms).
+    fn maintains_input_order(&self) -> Vec<bool> {
+        vec![false, false]
+    }
+
+    fn benefits_from_input_partitioning(&self) -> Vec<bool> {
+        vec![false, false]
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(RecursiveQueryExec::new(
+            self.name.clone(),
+            children[0].clone(),
+            children[1].clone(),
+            self.is_distinct,
+        )))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        // TODO: we might be able to handle multiple partitions in the future.
+        if partition != 0 {
+            return Err(DataFusionError::Internal(format!(
+                "RecursiveQueryExec got an invalid partition {} (expected 0)",
+                partition
+            )));
+        }
+
+        let static_stream = self.static_term.execute(partition, context.clone())?;
+        let baseline_metrics = BaselineMetrics::new(&self.metrics, partition);
+        Ok(Box::pin(RecursiveQueryStream::new(
+            context,
+            self.name.clone(),
+            self.recursive_term.clone(),
+            static_stream,
+            baseline_metrics,
+        )))
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+
+    fn statistics(&self) -> Statistics {
+        Statistics::default()
+    }
+}
+
+impl DisplayAs for RecursiveQueryExec {
+    fn fmt_as(
+        &self,
+        t: DisplayFormatType,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                write!(f, "RecursiveQueryExec: is_distinct={}", self.is_distinct)
+            }
+        }
+    }
+}
+
+/// The actual logic of the recursive queries happens during the streaming
+/// process. A simplified version of the algorithm is the following:
+///
+/// buffer = []
+///
+/// while batch := static_stream.next():
+///    buffer.push(batch)
+///    yield buffer
+///
+/// while buffer.len() > 0:
+///    sender, receiver = Channel()
+///    register_continuation(handle_name, receiver)
+///    sender.send(buffer.drain())
+///    recursive_stream = recursive_term.execute()
+///    while batch := recursive_stream.next():
+///        buffer.append(batch)
+///        yield buffer
+///
+struct RecursiveQueryStream {
+    /// The context to be used for managing handlers & executing new tasks
+    task_context: Arc<TaskContext>,
+    /// Name of the relation handler to be used by the recursive term
+    name: String,
+    /// The dynamic part (recursive term) as is (without being executed)
+    recursive_term: Arc<dyn ExecutionPlan>,
+    /// The static part (static term) as a stream. If the processing of this
+    /// part is completed, then it will be None.
+    static_stream: Option<SendableRecordBatchStream>,
+    /// The dynamic part (recursive term) as a stream. If the processing of this
+    /// part has not started yet, or has been completed, then it will be None.
+    recursive_stream: Option<SendableRecordBatchStream>,
+    /// The schema of the output.
+    schema: SchemaRef,
+    /// In-memory buffer for storing a copy of the current results. Will be
+    /// cleared after each iteration.
+    buffer: Vec<RecordBatch>,
+    // /// Metrics.
+    _baseline_metrics: BaselineMetrics,
+}
+
+impl RecursiveQueryStream {
+    /// Create a new recursive query stream
+    fn new(
+        task_context: Arc<TaskContext>,
+        name: String,
+        recursive_term: Arc<dyn ExecutionPlan>,
+        static_stream: SendableRecordBatchStream,
+        baseline_metrics: BaselineMetrics,
+    ) -> Self {
+        let schema = static_stream.schema();
+        Self {
+            task_context,
+            name,
+            recursive_term,
+            static_stream: Some(static_stream),
+            recursive_stream: None,
+            schema,
+            buffer: vec![],
+            _baseline_metrics: baseline_metrics,
+        }
+    }
+
+    /// Push a clone of the given batch to the in memory buffer, and then return
+    /// a poll with it.
+    fn push_batch(
+        mut self: std::pin::Pin<&mut Self>,
+        batch: RecordBatch,
+    ) -> Poll<Option<Result<RecordBatch>>> {
+        self.buffer.push(batch.clone());
+        Poll::Ready(Some(Ok(batch)))
+    }
+
+    /// Start polling for the next iteration, will be called either after the static term
+    /// is completed or another term is completed. It will follow the algorithm above on
+    /// to check whether the recursion has ended.
+    fn poll_next_iteration(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<RecordBatch>>> {
+        let total_length = self
+            .buffer
+            .iter()
+            .fold(0, |acc, batch| acc + batch.num_rows());
+
+        if total_length == 0 {
+            return Poll::Ready(None);
+        }
+
+        // The initial capacity of the channels is the same as the number of partitions
+        // we currently hold in the buffer.
+        let (sender, receiver): (
+            Sender<Result<RecordBatch>>,
+            Receiver<Result<RecordBatch>>,
+        ) = mpsc::channel(self.buffer.len() + 1);
+
+        // There shouldn't be any handlers with this name, since the execution of recursive
+        // term will immediately consume the relation handler.
+        self.task_context
+            .push_relation_handler(self.name.clone(), receiver)?;
+
+        // This part heavily assumes that the buffer is not going to change. Maybe we
+        // should use a mutex?
+        for batch in self.buffer.drain(..) {
+            match sender.try_send(Ok(batch.clone())) {
+                Ok(_) => {}
+                Err(e) => {
+                    return Poll::Ready(Some(Err(DataFusionError::ArrowError(
+                        ArrowError::from_external_error(Box::new(e)),
+                    ))));
+                }
+            }
+        }
+
+        // We always execute (and re-execute iteratively) the first partition.
+        // Downstream plans should not expect any partitioning.
+        let partition = 0;
+
+        self.recursive_stream = Some(
+            self.recursive_term
+                .execute(partition, self.task_context.clone())?,
+        );
+        self.poll_next(cx)
+    }
+}
+
+impl Stream for RecursiveQueryStream {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        // TODO: we should use this poll to record some metrics!
+        if let Some(static_stream) = &mut self.static_stream {
+            // While the static term's stream is available, we'll be forwarding the batches from it (also
+            // saving them for the initial iteration of the recursive term).
+            let poll = static_stream.poll_next_unpin(cx);
+            match &poll {
+                Poll::Ready(None) => {
+                    // Once this is done, we can start running the setup for the recursive term.
+                    self.static_stream = None;
+                    self.poll_next_iteration(cx)
+                }
+                Poll::Ready(Some(Ok(batch))) => self.push_batch(batch.clone()),
+                _ => poll,
+            }
+        } else if let Some(recursive_stream) = &mut self.recursive_stream {
+            let poll = recursive_stream.poll_next_unpin(cx);
+            match &poll {
+                Poll::Ready(None) => {
+                    self.recursive_stream = None;
+                    self.poll_next_iteration(cx)
+                }
+                Poll::Ready(Some(Ok(batch))) => self.push_batch(batch.clone()),
+                _ => poll,
+            }
+        } else {
+            Poll::Ready(None)
+        }
+    }
+}
+
+impl RecordBatchStream for RecursiveQueryStream {
+    /// Get the schema
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {}

--- a/datafusion/proto/src/logical_plan/mod.rs
+++ b/datafusion/proto/src/logical_plan/mod.rs
@@ -1429,6 +1429,12 @@ impl AsLogicalPlan for LogicalPlanNode {
             LogicalPlan::DescribeTable(_) => Err(proto_error(
                 "LogicalPlan serde is not yet implemented for DescribeTable",
             )),
+            LogicalPlan::NamedRelation(_) => Err(proto_error(
+                "LogicalPlan serde is not yet implemented for NamedRelation",
+            )),
+            LogicalPlan::RecursiveQuery(_) => Err(proto_error(
+                "LogicalPlan serde is not yet implemented for RecursiveQuery",
+            )),
         }
     }
 }

--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -47,6 +47,7 @@ use datafusion::physical_plan::windows::{create_window_expr, WindowAggExec};
 use datafusion::physical_plan::{
     udaf, AggregateExpr, ExecutionPlan, Partitioning, PhysicalExpr, WindowExpr,
 };
+// use datafusion::physical_plan::con
 use datafusion_common::FileCompressionType;
 use datafusion_common::{internal_err, not_impl_err, DataFusionError, Result};
 use prost::bytes::BufMut;

--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -47,7 +47,6 @@ use datafusion::physical_plan::windows::{create_window_expr, WindowAggExec};
 use datafusion::physical_plan::{
     udaf, AggregateExpr, ExecutionPlan, Partitioning, PhysicalExpr, WindowExpr,
 };
-// use datafusion::physical_plan::con
 use datafusion_common::FileCompressionType;
 use datafusion_common::{internal_err, not_impl_err, DataFusionError, Result};
 use prost::bytes::BufMut;

--- a/datafusion/sql/src/query.rs
+++ b/datafusion/sql/src/query.rs
@@ -20,13 +20,14 @@ use std::sync::Arc;
 use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
 
 use datafusion_common::{
-    not_impl_err, plan_err, sql_err, Constraints, DataFusionError, Result, ScalarValue,
+    plan_err, sql_err, Constraints, DFSchema, DataFusionError, Result, ScalarValue,
 };
 use datafusion_expr::{
     CreateMemoryTable, DdlStatement, Expr, LogicalPlan, LogicalPlanBuilder,
 };
 use sqlparser::ast::{
-    Expr as SQLExpr, Offset as SQLOffset, OrderByExpr, Query, SetExpr, Value,
+    Expr as SQLExpr, Offset as SQLOffset, OrderByExpr, Query, SetExpr, SetOperator,
+    SetQuantifier, Value,
 };
 
 use sqlparser::parser::ParserError::ParserError;
@@ -52,10 +53,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         let set_expr = query.body;
         if let Some(with) = query.with {
             // Process CTEs from top to bottom
-            // do not allow self-references
-            if with.recursive {
-                return not_impl_err!("Recursive CTEs are not supported");
-            }
+            let is_recursive = with.recursive;
 
             for cte in with.cte_tables {
                 // A `WITH` block can't use the same name more than once
@@ -65,16 +63,130 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         "WITH query name {cte_name:?} specified more than once"
                     )));
                 }
-                // create logical plan & pass backreferencing CTEs
-                // CTE expr don't need extend outer_query_schema
-                let logical_plan =
-                    self.query_to_plan(*cte.query, &mut planner_context.clone())?;
+                let cte_query = cte.query;
+                if is_recursive {
+                    match *cte_query.body {
+                        SetExpr::SetOperation {
+                            op: SetOperator::Union,
+                            left,
+                            right,
+                            set_quantifier,
+                        } => {
+                            let distinct = set_quantifier != SetQuantifier::All;
 
-                // Each `WITH` block can change the column names in the last
-                // projection (e.g. "WITH table(t1, t2) AS SELECT 1, 2").
-                let logical_plan = self.apply_table_alias(logical_plan, cte.alias)?;
+                            // Each recursive CTE consists from two parts in the logical plan:
+                            //   1. A static term   (the left hand side on the SQL, where the
+                            //                       referencing to the same CTE is not allowed)
+                            //
+                            //   2. A recursive term (the right hand side, and the recursive
+                            //                       part)
 
-                planner_context.insert_cte(cte_name, logical_plan);
+                            // Since static term does not have any specific properties, it can
+                            // be compiled as if it was a regular expression. This will
+                            // allow us to infer the schema to be used in the recursive term.
+
+                            // ---------- Step 1: Compile the static term ------------------
+                            let static_plan = self
+                                .set_expr_to_plan(*left, &mut planner_context.clone())?;
+
+                            // Since the recursive CTEs include a component that references a
+                            // table with its name, like the example below:
+                            //
+                            // WITH RECURSIVE values(n) AS (
+                            //      SELECT 1 as n -- static term
+                            //    UNION ALL
+                            //      SELECT n + 1
+                            //      FROM values -- self reference
+                            //      WHERE n < 100
+                            // )
+                            //
+                            // We need a temporary 'relation' to be referenced and used. PostgreSQL
+                            // calls this a 'working table', but it is entirely an implementation
+                            // detail and a 'real' table with that name might not even exist (as
+                            // in the case of DataFusion).
+                            //
+                            // Since we can't simply register a table during planning stage (it is
+                            // an execution problem), we'll use a relation object that preserves the
+                            // schema of the input perfectly and also knows which recursive CTE it is
+                            // bound to.
+
+                            // ---------- Step 2: Create a temporary relation ------------------
+                            // Step 2.1: Create a schema for the temporary relation
+                            let static_fields = static_plan.schema().fields().clone();
+                            let static_metadata = static_plan.schema().metadata().clone();
+
+                            let named_relation_schema = DFSchema::new_with_metadata(
+                                // take the fields from the static plan
+                                // but add the cte_name as the qualifier
+                                // so that we can access the fields in the recursive term using
+                                // the cte_name as the qualifier (e.g. table.id)
+                                static_fields
+                                    .into_iter()
+                                    .map(|field| {
+                                        if field.qualifier().is_some() {
+                                            field
+                                        } else {
+                                            field.with_qualifier(cte_name.clone())
+                                        }
+                                    })
+                                    .collect(),
+                                static_metadata,
+                            )?;
+
+                            // Step 2.2: Create a temporary relation logical plan that will be used
+                            // as the input to the recursive term
+                            let named_relation = LogicalPlanBuilder::named_relation(
+                                cte_name.as_str(),
+                                Arc::new(named_relation_schema),
+                            )
+                            .build()?;
+
+                            // Step 2.3: Register the temporary relation in the planning context
+                            // For all the self references in the variadic term, we'll replace it
+                            // with the temporary relation we created above by temporarily registering
+                            // it as a CTE. This temporary relation in the planning context will be
+                            // replaced by the actual CTE plan once we're done with the planning.
+                            planner_context.insert_cte(cte_name.clone(), named_relation);
+
+                            // ---------- Step 3: Compile the recursive term ------------------
+                            // this uses the named_relation we inserted above to resolve the
+                            // relation. This ensures that the recursive term uses the named relation logical plan
+                            // and thus the 'continuance' physical plan as its input and source
+                            let recursive_plan = self
+                                .set_expr_to_plan(*right, &mut planner_context.clone())?;
+
+                            // ---------- Step 4: Create the final plan ------------------
+                            // Step 4.1: Compile the final plan
+                            let final_plan = LogicalPlanBuilder::from(static_plan)
+                                .to_recursive_query(
+                                    cte_name.clone(),
+                                    recursive_plan,
+                                    distinct,
+                                )?
+                                .build()?;
+
+                            // Step 4.2: Remove the temporary relation from the planning context and replace it
+                            // with the final plan.
+                            planner_context.insert_cte(cte_name.clone(), final_plan);
+                        }
+                        _ => {
+                            return Err(DataFusionError::SQL(ParserError(
+                                "Invalid recursive CTE".to_string(),
+                            )));
+                        }
+                    };
+                } else {
+                    // create logical plan & pass backreferencing CTEs
+                    // CTE expr don't need extend outer_query_schema
+                    let logical_plan =
+                        self.query_to_plan(*cte_query, &mut planner_context.clone())?;
+
+                    // Each `WITH` block can change the column names in the last
+                    // projection (e.g. "WITH table(t1, t2) AS SELECT 1, 2").
+                    let logical_plan = self.apply_table_alias(logical_plan, cte.alias)?;
+
+                    planner_context.insert_cte(cte_name, logical_plan);
+                }
             }
         }
         let plan = self.set_expr_to_plan(*(set_expr.clone()), planner_context)?;


### PR DESCRIPTION
- partway through porting over isidentical's work
- Continuing implementation with fixes and improvements
- ensure that repartitions are not added immediately after RecursiveExec in the physical-plan
- compiles and tests pass
- cleanup in enforce_distribution.rs
